### PR TITLE
Use unified host name

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	builder := &builders.NetworkBuilder{}
 	builder.SetKeys(keys)
-	builder.SetAddress(host)
+	builder.SetHost(host)
 	builder.SetPort(port)
 
 	// Register peer discovery RPC handlers.

--- a/network/builders/network.go
+++ b/network/builders/network.go
@@ -15,7 +15,7 @@ import (
 
 type NetworkBuilder struct {
 	keys    *crypto.KeyPair
-	address string
+	host    string
 	port    int
 
 	// map[string]MessageProcessor
@@ -26,8 +26,8 @@ func (builder *NetworkBuilder) SetKeys(pair *crypto.KeyPair) {
 	builder.keys = pair
 }
 
-func (builder *NetworkBuilder) SetAddress(address string) {
-	builder.address = address
+func (builder *NetworkBuilder) SetHost(host string) {
+	builder.host = host
 }
 
 func (builder *NetworkBuilder) SetPort(port int) {
@@ -57,7 +57,7 @@ func (builder *NetworkBuilder) BuildNetwork() (*network.Network, error) {
 		return nil, errors.New("cryptography keypair not provided to Network; cannot create node Id")
 	}
 
-	if len(builder.address) == 0 {
+	if len(builder.host) == 0 {
 		return nil, errors.New("Network requires public server IP for peers to connect to")
 	}
 
@@ -70,11 +70,16 @@ func (builder *NetworkBuilder) BuildNetwork() (*network.Network, error) {
 		builder.processors = &sync.Map{}
 	}
 
-	id := peer.CreateID(builder.address+":"+strconv.Itoa(builder.port), builder.keys.PublicKey)
+	unifiedHost, err := network.ToUnifiedHost(builder.host)
+	if err != nil {
+		return nil, err
+	}
+
+	id := peer.CreateID(unifiedHost+":"+strconv.Itoa(builder.port), builder.keys.PublicKey)
 
 	network := &network.Network{
 		Keys:    builder.keys,
-		Address: builder.address,
+		Host:    unifiedHost,
 		Port:    builder.port,
 		ID:      id,
 

--- a/network/utils.go
+++ b/network/utils.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	"net"
+	"errors"
+)
+
+func ToUnifiedHost(host string) (string, error) {
+	if net.ParseIP(host) == nil {
+		// Probably a domain name is provided.
+		addrs, err := net.LookupHost(host)
+		if err != nil {
+			return "", err
+		}
+		if len(addrs) == 0 {
+			return "", errors.New("no available addresses")
+		}
+
+		host = addrs[0]
+	}
+
+	return host, nil
+}
+
+func ToUnifiedAddress(address string) (string, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", err
+	}
+
+	host, err = ToUnifiedHost(host)
+	if err != nil {
+		return "", err
+	}
+
+	return net.JoinHostPort(host, port), nil
+}

--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -1,0 +1,26 @@
+package network
+
+import (
+	"testing"
+	"net"
+	"strings"
+)
+
+func TestToUnifiedAddress(t *testing.T) {
+	addr, err := ToUnifiedAddress("localhost:1000")
+	if err != nil {
+		panic(err)
+	}
+
+	ip, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		panic(err)
+	}
+
+	if !strings.HasPrefix(ip, "127.") && !strings.HasPrefix(ip, "::") {
+		panic("localhost resolved to invalid address " + ip)
+	}
+	if port != "1000" {
+		panic("port mismatch")
+	}
+}


### PR DESCRIPTION
Resolve all host names to IP addresses to avoid inconsistency.