### PR TITLE
Fix the proxy example

### DIFF
--- a/examples/proxy/proxy_test.go
+++ b/examples/proxy/proxy_test.go
@@ -111,7 +111,7 @@ func ExampleProxy() {
 		builder.SetAddress(addr)
 
 		discovery := new(discovery.Plugin)
-		discovery.DisableDialing = true
+		discovery.DisablePong = true
 		builder.AddPlugin(discovery)
 
 		processors = append(processors, new(ProxyPlugin))

--- a/network/discovery/plugin.go
+++ b/network/discovery/plugin.go
@@ -15,8 +15,8 @@ type Plugin struct {
 
 	Routes *dht.RoutingTable
 
-	// DisableDialing when enable overrides dialing out to new nodes (default: false)
-	DisableDialing bool
+	// DisablePong when enable overrides dialing out to new nodes (default: false)
+	DisablePong bool
 }
 
 var PluginID = (*Plugin)(nil)
@@ -41,8 +41,7 @@ func (state *Plugin) Receive(ctx *network.MessageContext) error {
 			return err
 		}
 	case *protobuf.Pong:
-		if state.DisableDialing {
-			// override dial behavior
+		if state.DisablePong {
 			break
 		}
 


### PR DESCRIPTION
- seems PONG adds new connected peers to the network, so the topology added randomly
- think fix keeps the network peer connections unaltered after bootstrap