### PR TITLE
pprof: add pprof web handlers to cluster benchmark

### DIFF
--- a/examples/cluster_benchmark/main.go
+++ b/examples/cluster_benchmark/main.go
@@ -67,6 +67,10 @@ func setupPPROF(port int) {
 	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	r.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	r.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	r.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	r.Handle("/debug/pprof/block", pprof.Handler("block"))
 
 	glog.Infof("Pprof listening on port %d.\n", port+500)
 	http.ListenAndServe(fmt.Sprintf(":%d", port+500), r)


### PR DESCRIPTION
```
// Usage:
// terminal_1$ vgo build && ./cluster_benchmark -port 3000
// terminal_2$ ./cluster_benchmark -port 3001 -peers tcp://localhost:3000
// terminal_3:
//  go tool pprof cluster_benchmark http://127.0.0.1:3500/debug/pprof/profile
//  go tool pprof cluster_benchmark http://127.0.0.1:3500/debug/pprof/heap
//  go tool pprof cluster_benchmark http://127.0.0.1:3500/debug/pprof/goroutine
//  go tool pprof cluster_benchmark http://127.0.0.1:3500/debug/pprof/block
//    (can use the command "top" when prompted in pprof)
```