### PR TITLE
Have disjoint path lookups occur in parallel to adhere to S/Kademlia.

### DIFF
--- a/dht/routes.go
+++ b/dht/routes.go
@@ -8,9 +8,8 @@ import (
 	"github.com/perlin-network/noise/peer"
 )
 
-// BucketSize defines the NodeID, Key, and routing table datastructures
-// In Kademlia, proper bucket size is 20bytes/160bits
-const BucketSize = 20
+// BucketSize defines the NodeID, Key, and routing table data structures.
+const BucketSize = 16
 
 // RoutingTable contains one bucket list for lookups
 type RoutingTable struct {

--- a/dht/routes_test.go
+++ b/dht/routes_test.go
@@ -27,12 +27,6 @@ func RandByte() byte {
 	return MustReadRand(1)[0]
 }
 
-func TestBucketSize(t *testing.T) {
-	if BucketSize != 20 {
-		t.Fatalf("bucket size is expected %d but found %d", 20, BucketSize)
-	}
-}
-
 func TestSelf(t *testing.T) {
 	publicKey := MustReadRand(32)
 	id := peer.CreateID("0000", publicKey)
@@ -46,11 +40,12 @@ func TestSelf(t *testing.T) {
 }
 
 func TestPeerExists(t *testing.T) {
-
 	id1 := peer.CreateID("0000", MustReadRand(32))
 	id2 := peer.CreateID("0001", MustReadRand(32))
+
 	routingTable := CreateRoutingTable(id1)
 	routingTable.Update(id2)
+
 	if !routingTable.PeerExists(id1) {
 		t.Fatal("peerexists() targeting self failed")
 	}

--- a/network/discovery/plugin.go
+++ b/network/discovery/plugin.go
@@ -49,7 +49,7 @@ func (state *Plugin) Receive(ctx *network.PluginContext) error {
 			break
 		}
 
-		peers := FindNode(ctx.Network(), ctx.Sender(), dht.BucketSize)
+		peers := FindNode(ctx.Network(), ctx.Sender(), dht.BucketSize, 8)
 
 		// Update routing table w/ closest peers to self.
 		for _, peerID := range peers {


### PR DESCRIPTION
Stick closer to S/Kademlia specification.