### PR TITLE
Ignore Edwards25519 from coverage.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,7 @@ ignore:
   - "**/mocks"
   - "**/*.pb.go"
   - "scripts.go"
+  - "./crypto/ed25519/internal/edwards25519"
 
 comment: false
 


### PR DESCRIPTION
- seems like mostly generated external assembly code: crypto/ed25519/internal/edwards25519
- this restores coverage from 29% -> 55%