### PR TITLE
Pluggable transport layers.

### DIFF
--- a/network/builder.go
+++ b/network/builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/perlin-network/noise/crypto/ed25519"
 	"github.com/perlin-network/noise/peer"
 	"github.com/pkg/errors"
+	"github.com/perlin-network/noise/network/transport"
 )
 
 const (
@@ -35,6 +36,8 @@ type Builder struct {
 
 	plugins     *PluginList
 	pluginCount int
+
+	transports *sync.Map
 }
 
 var defaultBuilderOptions = options{
@@ -117,11 +120,18 @@ func WriteTimeout(d time.Duration) BuilderOption {
 
 // NewBuilder returns a new builder with default options.
 func NewBuilder() *Builder {
-	return &Builder{
+	builder := &Builder{
 		opts:    defaultBuilderOptions,
 		address: defaultAddress,
 		keys:    ed25519.RandomKeyPair(),
+		transports: new(sync.Map),
 	}
+
+	// Register default transport layers.
+	builder.RegisterTransportLayer("tcp", transport.NewTCP())
+	builder.RegisterTransportLayer("kcp", transport.NewKCP())
+
+	return builder
 }
 
 // NewBuilderWithOptions returns a new builder with specified options.
@@ -168,6 +178,18 @@ func (builder *Builder) AddPlugin(plugin PluginInterface) error {
 	return err
 }
 
+// RegisterTransportLayer registers a transport layer to the network keyed by its name.
+//
+// Example: builder.RegisterTransportLayer("kcp", transport.NewKCP())
+func (builder *Builder) RegisterTransportLayer(name string, layer transport.Layer) {
+	builder.transports.Store(name, layer)
+}
+
+// ClearTransportLayers removes all registered transport layers from the builder.
+func (builder *Builder) ClearTransportLayers() {
+	builder.transports = new(sync.Map)
+}
+
 // Build verifies all parameters of the network and returns either an error due to
 // misconfiguration, or a *Network.
 func (builder *Builder) Build() (*Network, error) {
@@ -200,6 +222,8 @@ func (builder *Builder) Build() (*Network, error) {
 		Address: unifiedAddress,
 
 		Plugins: builder.plugins,
+
+		Transports: builder.transports,
 
 		Peers: new(sync.Map),
 

--- a/network/transport/kcp.go
+++ b/network/transport/kcp.go
@@ -1,0 +1,50 @@
+package transport
+
+import (
+	"net"
+	"github.com/xtaci/kcp-go"
+	"strconv"
+	)
+
+// KCP represents the KCP transport protocol alongside its respective configurable options.
+type KCP struct {
+	DataShards int
+	ParityShards int
+	SendWindowSize int
+	RecvWindowSize int
+}
+
+// NewKCP instantiates a new instance of the KCP transport protocol.
+func NewKCP() *KCP {
+	return &KCP{
+		DataShards: 0,
+		ParityShards: 0,
+		SendWindowSize: 10000,
+		RecvWindowSize: 10000,
+	}
+}
+
+// Listen listens for incoming KCP connections on a specified port, with optional Reed-Solomon message sharding.
+func (t *KCP) Listen(port int) (net.Listener, error) {
+	listener, err := kcp.ListenWithOptions(":"+strconv.Itoa(port), nil, t.DataShards, t.ParityShards)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return listener, nil
+}
+
+// Dial dials an address via. the KCP protocol, with optional Reed-Solomon message sharding and
+// send/receive window size configurations.
+func (t *KCP) Dial(address string) (net.Conn, error) {
+	conn, err := kcp.DialWithOptions(address, nil, t.DataShards, t.ParityShards)
+	conn.SetWindowSize(t.SendWindowSize, t.RecvWindowSize)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+

--- a/network/transport/tcp.go
+++ b/network/transport/tcp.go
@@ -1,0 +1,45 @@
+package transport
+
+import (
+	"net"
+		"strconv"
+	)
+
+type TCP struct {
+	WriteBufferSize int
+	NoDelay bool
+}
+
+func NewTCP() *TCP {
+	return &TCP{
+		WriteBufferSize: 10000,
+		NoDelay: false,
+	}
+}
+
+func (t *TCP) Listen(port int) (net.Listener, error) {
+	listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+	if err != nil {
+		return nil, err
+	}
+
+	return listener, nil
+}
+
+func (t *TCP) Dial(address string) (net.Conn, error) {
+	resolved, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	onn, err := net.DialTCP("tcp", nil, resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	onn.SetWriteBuffer(t.WriteBufferSize)
+	onn.SetNoDelay(t.NoDelay)
+
+	return onn, nil
+}
+

--- a/network/transport/transport.go
+++ b/network/transport/transport.go
@@ -1,0 +1,8 @@
+package transport
+
+import "net"
+
+type Layer interface {
+	Listen(port int) (net.Listener, error)
+	Dial(address string) (net.Conn, error)
+}


### PR DESCRIPTION
Allows for users to register custom transport layers into Noise; addresses #107.

transport: Created interfaces for transport layers.
network: Allowed transport layers to be pluggable.
network/builder: Provided options for registering/removing transport layers to a network.