### PR TITLE
network: added error and handle if client stream remains open but client is never initialized

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -408,6 +408,11 @@ func (n *Network) Accept(incoming net.Conn) {
 			client.setIncomingReady()
 		})
 
+		if client == nil {
+			log.Error().Msg("client initialization failed, ignoring new message from peer")
+			return
+		}
+
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return


### PR DESCRIPTION
Handles an error that occurs when a peer dials itself (or a remote peer is bound to localhost/0.0.0.0 and dials) the client object would never be initialized because the block

```golang
clientInit.Do(func() {
    client, err = n.Client(msg.Sender.Address)
    if err != nil {
      fmt.Println(err)
      return
    }

    client.ID = (*peer.ID)(msg.Sender)

    // Load an outgoing connection.
    if state, established := n.Connections.Load(client.ID.Address); established {
      outgoing = state.(*ConnState).conn
    } else {
      err = errors.New("network: failed to load session")
    }

    // Signal that the client is ready.
    close(client.incomingReady)
})
```
only being executed once and leaving the client object as nil, causing the peer to panic. There may be a better fix by closing the accept loop for that peer, but I wasn't able to find a good way to do that given the current design.