### PR TITLE
NAT Traversal Bug: accidentally listening on external router port

### DIFF
--- a/network/nat/plugin.go
+++ b/network/nat/plugin.go
@@ -74,7 +74,7 @@ func (p *plugin) Startup(n *network.Network) {
 		Str("external_ip", p.externalIP.String()).
 		Msg("")
 
-	p.externalPort, err = gateway.AddPortMapping("tcp", p.internalPort, "noise", 1*time.Second)
+	p.externalPort, err = gateway.AddPortMapping("tcp", p.internalPort, "noise", 60*time.Second)
 
 	if err != nil {
 		log.Warn().
@@ -90,14 +90,21 @@ func (p *plugin) Startup(n *network.Network) {
 
 	p.gateway = gateway
 
-	info.Host = p.externalIP.String()
-	info.Port = uint16(p.externalPort)
+	// info.Host = p.internalIP.String()
+	// info.Port = uint16(p.internalPort)
 
+	externalAddress := network.AddressInfo{
+		Host:     p.externalIP.String(),
+		Port:     uint16(p.externalPort),
+		Protocol: "tcp",
+	}
 	// Set peer information based off of port mapping info.
 	n.Address = info.String()
 	n.ID = peer.CreateID(n.Address, n.GetKeys().PublicKey)
 
-	log.Info().Msgf("other peers may connect to you through the address %s.", n.Address)
+	log.Info().
+		Str("address", externalAddress.String()).
+		Msg("port-forwarded external address.")
 }
 
 func (p *plugin) Cleanup(n *network.Network) {
@@ -116,5 +123,6 @@ func (p *plugin) Cleanup(n *network.Network) {
 //
 // The plugin is registered with a priority of -999999, and thus is executed first.
 func RegisterPlugin(builder *network.Builder) {
-	builder.AddPluginWithPriority(-99999, new(plugin))
+	x := new(plugin)
+	builder.AddPluginWithPriority(-99999, x)
 }

--- a/network/network.go
+++ b/network/network.go
@@ -233,7 +233,7 @@ func (n *Network) Listen() {
 
 	log.Info().
 		Str("address", n.Address).
-		Msg("Listening for peers.")
+		Msg("Listening on: ")
 
 	// handle server shutdowns
 	go func() {


### PR DESCRIPTION
This fix allows the forwarded port to correctly accept comms. The server was listening on the external router port, but the router was forwarding to the internal ip. Subsequently, any forwarded traffic would hit a closed port and refuse connection.