### PR TITLE
removing empty host limitation and adding external IP config

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package noise
 
 type Config struct {
 	Host            string
+	ExternalAddress	string
 	Port            int
 	PrivateKeyHex   string
 	EnableSKademlia bool

--- a/noise.go
+++ b/noise.go
@@ -98,7 +98,12 @@ func NewNoise(config *Config) (*Noise, error) {
 	)
 
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
+
+	// manage external address if specified in config
 	extAddr := fmt.Sprintf("%s:%d", config.ExternalAddress, config.Port)
+	if config.ExternalAddress == "" {
+		extAddr = addr
+	}
 
 	listener, err := net.Listen("tcp", addr)
 

--- a/noise.go
+++ b/noise.go
@@ -48,9 +48,6 @@ func CreatePeerID(publicKey []byte, addr string) PeerID {
 
 // NewNoise creates a new Noise instance with the correct configuration
 func NewNoise(config *Config) (*Noise, error) {
-	if len(config.Host) == 0 {
-		return nil, errors.New("Host is missing")
-	}
 	if config.Port < 1024 || config.Port > 65535 {
 		return nil, errors.Errorf("Invalid config port: %d", config.Port)
 	}

--- a/noise.go
+++ b/noise.go
@@ -88,6 +88,7 @@ func NewNoise(config *Config) (*Noise, error) {
 	meta["keypair"] = idAdapter.GetKeyPair()
 	meta["self"] = CreatePeerID(idAdapter.MyIdentity(), fmt.Sprintf("%s:%d", config.Host, config.Port))
 	meta["host"] = config.Host
+	meta["extAddress"] = config.ExternalAddress
 	meta["port"] = config.Port
 	meta["enable_skademlia"] = config.EnableSKademlia
 
@@ -97,13 +98,16 @@ func NewNoise(config *Config) (*Noise, error) {
 	)
 
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
+	extAddr := fmt.Sprintf("%s:%d", config.ExternalAddress, config.Port)
+
 	listener, err := net.Listen("tcp", addr)
+
 	if err != nil {
 		return nil, err
 	}
 
 	if config.EnableSKademlia {
-		if _, err := skademlia.NewConnectionAdapter(listener, dialTCP, node, addr); err != nil {
+		if _, err := skademlia.NewConnectionAdapter(listener, dialTCP, node, extAddr); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
- in fact if you want your application to listen for remote peer addresses (and not only on localhost/127.0.0.1), the only solution available in golang is to call net.Listen("tcp", ":_PORT_") with a nil/empty host, see https://golang.org/pkg/net/#ListenIP
- this is a useful fix when you want to dockerise a noise-based app

Keep up the good work!