### PR TITLE
Fix race condition over the network for AEAD.

### DIFF
--- a/callbacks/reduce.go
+++ b/callbacks/reduce.go
@@ -31,10 +31,3 @@ func (m *ReduceCallbackManager) RunCallbacks(in interface{}, params ...interface
 	res = in
 	return
 }
-
-// MustRunCallbacks runs all callbacks on a variadic parameter list, and de-registers callbacks
-// that throw an error. Errors are ignored.
-func (m *ReduceCallbackManager) MustRunCallbacks(in interface{}, params ...interface{}) interface{} {
-	out, _ := m.RunCallbacks(in, params...)
-	return out
-}

--- a/cipher/aead/crypto.go
+++ b/cipher/aead/crypto.go
@@ -3,7 +3,6 @@ package aead
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"github.com/perlin-network/noise/internal/edwards25519"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/hkdf"
 	"hash"
@@ -25,16 +24,4 @@ func deriveCipherSuite(fn func() hash.Hash, ephemeralSharedKey []byte, context [
 	gcm, _ := cipher.NewGCM(block)
 
 	return gcm, sharedKey, nil
-}
-
-func isEd25519GroupElement(buf []byte) bool {
-	if len(buf) != edwards25519.PublicKeySize {
-		return false
-	}
-
-	var buff [32]byte
-	copy(buff[:], buf)
-
-	var A edwards25519.ExtendedGroupElement
-	return A.FromBytes(&buff)
 }

--- a/cipher/aead/mod_test.go
+++ b/cipher/aead/mod_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/perlin-network/noise/transport"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"strings"
 	"testing"
 	"time"
 )
@@ -83,14 +82,6 @@ func TestBlock_OnBeginEdgeCases(t *testing.T) {
 
 	// Expect a disconnect calling OnBegin without Bob yet having an ephemeral shared key.
 	assert.True(t, errors.Cause(block.OnBegin(proto, peerBob1)) == protocol.DisconnectPeer)
-
-	// Now set an invalid ephemeral shared key to Bob, and check OnBegin fails
-	peerBob2, err := alice.Dial(bob.ExternalAddress())
-	assert.NoError(t, err)
-	defer peerBob2.Disconnect()
-
-	protocol.SetSharedKey(peerBob2, []byte("test ephemeral key"))
-	assert.True(t, strings.Contains(block.OnBegin(proto, peerBob2).Error(), "failed to unmarshal ephemeral shared key buf"))
 
 	// Now restart connections, and set a proper ephemeral shared key to Bob.
 	ephemeralSharedKey, err := hex.DecodeString("d8747263b4d54588c2c8f17862d827dee6d3893a02fb7a84800b001ad4f1cee8")

--- a/examples/benchmark/main.go
+++ b/examples/benchmark/main.go
@@ -85,7 +85,7 @@ func main() {
 				_, _ = rand.Read(payload)
 
 				atomic.AddUint64(&messagesSentPerSecond, 1)
-				_ = peer.SendMessage(benchmarkMessage{string(payload)})
+				_ = peer.SendMessageAsync(benchmarkMessage{text: string(payload)})
 			}
 		}()
 

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -115,6 +115,6 @@ func main() {
 			panic(err)
 		}
 
-		_ = skademlia.Broadcast(node, chatMessage{text: strings.TrimSpace(txt)})
+		_ = skademlia.BroadcastAsync(node, chatMessage{text: strings.TrimSpace(txt)})
 	}
 }

--- a/examples/e2e/e2e_test.go
+++ b/examples/e2e/e2e_test.go
@@ -109,6 +109,7 @@ func Run(numNodes int, numTxEach int) error {
 			peer, err := nodes[i].Dial(nodes[0].ExternalAddress())
 			if err != nil {
 				errors = append(errors, err)
+				return
 			}
 
 			skademlia.WaitUntilAuthenticated(peer)

--- a/examples/e2e/e2e_test.go
+++ b/examples/e2e/e2e_test.go
@@ -133,7 +133,7 @@ func Run(numNodes int, numTxEach int) error {
 			for j := 0; j < numTxEach; j++ {
 				txt := fmt.Sprintf("sending from %d tx %d", i, j)
 
-				errs := skademlia.Broadcast(nodes[i], testMessage{text: strings.TrimSpace(txt)})
+				errs := skademlia.BroadcastAsync(nodes[i], testMessage{text: strings.TrimSpace(txt)})
 				if len(errs) > 0 {
 					errors = append(errors, errs...)
 				}

--- a/examples/e2e/e2e_test.go
+++ b/examples/e2e/e2e_test.go
@@ -133,9 +133,18 @@ func Run(numNodes int, numTxEach int) error {
 			for j := 0; j < numTxEach; j++ {
 				txt := fmt.Sprintf("sending from %d tx %d", i, j)
 
-				errs := skademlia.BroadcastAsync(nodes[i], testMessage{text: strings.TrimSpace(txt)})
-				if len(errs) > 0 {
-					errors = append(errors, errs...)
+				errCh := skademlia.BroadcastAsync(nodes[i], testMessage{text: strings.TrimSpace(txt)})
+
+				for {
+					select {
+					case err := <-errCh:
+						if err != nil {
+							errors = append(errors, err)
+						}
+					default:
+					}
+
+					break
 				}
 			}
 		}(i)

--- a/node.go
+++ b/node.go
@@ -25,6 +25,11 @@ type Node struct {
 
 	maxMessageSize uint64
 
+	sendMessageTimeout    time.Duration
+	receiveMessageTimeout time.Duration
+
+	sendWorkerBusyTimeout time.Duration
+
 	onListenerErrorCallbacks *callbacks.SequentialCallbackManager
 	onPeerConnectedCallbacks *callbacks.SequentialCallbackManager
 	onPeerDialedCallbacks    *callbacks.SequentialCallbackManager
@@ -63,6 +68,11 @@ func NewNode(params parameters) (*Node, error) {
 		port:     params.Port,
 
 		maxMessageSize: params.MaxMessageSize,
+
+		sendMessageTimeout:    params.SendMessageTimeout,
+		receiveMessageTimeout: params.ReceiveMessageTimeout,
+
+		sendWorkerBusyTimeout: params.SendWorkerBusyTimeout,
 
 		onListenerErrorCallbacks: callbacks.NewSequentialCallbackManager(),
 		onPeerConnectedCallbacks: callbacks.NewSequentialCallbackManager(),

--- a/params.go
+++ b/params.go
@@ -4,6 +4,7 @@ import (
 	"github.com/perlin-network/noise/identity"
 	"github.com/perlin-network/noise/nat"
 	"github.com/perlin-network/noise/transport"
+	"time"
 )
 
 type parameters struct {
@@ -17,6 +18,11 @@ type parameters struct {
 	Metadata map[string]interface{}
 
 	MaxMessageSize uint64
+
+	SendMessageTimeout    time.Duration
+	ReceiveMessageTimeout time.Duration
+
+	SendWorkerBusyTimeout time.Duration
 }
 
 func DefaultParams() parameters {
@@ -25,5 +31,10 @@ func DefaultParams() parameters {
 		Transport:      transport.NewTCP(),
 		Metadata:       map[string]interface{}{},
 		MaxMessageSize: 1048576,
+
+		SendMessageTimeout:    3 * time.Second,
+		ReceiveMessageTimeout: 3 * time.Second,
+
+		SendWorkerBusyTimeout: 3 * time.Second,
 	}
 }

--- a/skademlia/mod.go
+++ b/skademlia/mod.go
@@ -184,5 +184,5 @@ func (b *block) handleLookups(peer *noise.Peer) {
 }
 
 func WaitUntilAuthenticated(peer *noise.Peer) {
-	<-peer.LoadOrStore(keyAuthChannel, make(chan struct{}, 1)).(chan struct{})
+	<-peer.LoadOrStore(keyAuthChannel, make(chan struct{})).(chan struct{})
 }

--- a/skademlia/table_test.go
+++ b/skademlia/table_test.go
@@ -280,7 +280,6 @@ func TestTable(t *testing.T) {
 
 	node, err := noise.NewNode(params)
 	assert.Nil(t, err)
-	defer node.Kill()
 
 	id := NewID(node.ExternalAddress(), keys.PublicKey(), keys.Nonce)
 

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"net"
+	"time"
 )
 
 var _ Layer = (*tcp)(nil)
@@ -28,12 +29,7 @@ func (t tcp) Listen(host string, port uint16) (net.Listener, error) {
 }
 
 func (t tcp) Dial(address string) (net.Conn, error) {
-	resolved, err := net.ResolveTCPAddr("tcp", address)
-	if err != nil {
-		return nil, err
-	}
-
-	conn, err := net.DialTCP("tcp", nil, resolved)
+	conn, err := net.DialTimeout("tcp", address, 3*time.Second)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There is a race condition that I and @losfair have been trying to fix for awhile now.

The race condition goes as follows:
1) I send aead.ACK.
2) Peer sends aead.ACK.
3) Peer receives aead.ACK and sends skademlia.Ping, but we haven't atomically locked all reads yet.

Thus, we receive skademlia.Ping encrypted (as after aead.ACK is received, we enable AEAD encryption), and are unable to decode it as we have not enabled AEAD as of yet.

To reproduce, `cd` to `examples/e2e` and run `go test -v -count=100`, and you will see disconnections/failure to read encrypted messages.

![image](https://user-images.githubusercontent.com/8392982/52903587-8cab6900-325a-11e9-85c1-676523b6f89e.png)
