### PR TITLE
Fix a bug that happens when peer's connection is closed by the dialler.

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -255,6 +255,8 @@ func TestCallbacks(t *testing.T) {
 
 		peer.Disconnect()
 
+		time.Sleep(10 * time.Millisecond)
+
 		// check that the expected callbacks were called on the dialer
 		compareCB(callbacks[src], map[string]int{
 			"OnPeerDisconnected": 1,

--- a/node_test.go
+++ b/node_test.go
@@ -253,7 +253,7 @@ func TestCallbacks(t *testing.T) {
 
 		clearCounters()
 
-		<-peer.DisconnectAsync()
+		peer.Disconnect()
 
 		// check that the expected callbacks were called on the dialer
 		compareCB(callbacks[src], map[string]int{

--- a/peer.go
+++ b/peer.go
@@ -185,14 +185,14 @@ func (p *Peer) spawnReceiveWorker() {
 				p.onConnErrorCallbacks.RunCallbacks(p.node, errors.Wrap(err, "failed to read message size"))
 			}
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 
 		if size > p.node.maxMessageSize {
 			p.onConnErrorCallbacks.RunCallbacks(p.node, errors.Errorf("exceeded max message size; got size %d", size))
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 
@@ -202,14 +202,14 @@ func (p *Peer) spawnReceiveWorker() {
 		if err != nil {
 			p.onConnErrorCallbacks.RunCallbacks(p.node, errors.Wrap(err, "failed to read remaining message contents"))
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 
 		if seen < int(size) {
 			p.onConnErrorCallbacks.RunCallbacks(p.node, errors.Errorf("only read %d bytes when expected to read %d from peer", seen, size))
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 
@@ -217,7 +217,7 @@ func (p *Peer) spawnReceiveWorker() {
 		if len(errs) > 0 {
 			log.Warn().Errs("errors", errs).Msg("Got errors running BeforeMessageReceived callbacks.")
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 		buf = b.([]byte)
@@ -227,7 +227,7 @@ func (p *Peer) spawnReceiveWorker() {
 		if opcode == OpcodeNil || err != nil {
 			p.onConnErrorCallbacks.RunCallbacks(p.node, errors.Wrap(err, "failed to decode message"))
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 
@@ -239,14 +239,14 @@ func (p *Peer) spawnReceiveWorker() {
 			recv.lock <- struct{}{}
 			<-recv.lock
 		case <-time.After(p.node.receiveMessageTimeout):
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 
 		if errs := p.afterMessageReceivedCallbacks.RunCallbacks(p.node); len(errs) > 0 {
 			log.Warn().Errs("errors", errs).Msg("Got errors running AfterMessageReceived callbacks.")
 
-			p.Disconnect()
+			p.DisconnectAsync()
 			continue
 		}
 	}

--- a/protocol/mod_test.go
+++ b/protocol/mod_test.go
@@ -80,5 +80,5 @@ func TestProtocol(t *testing.T) {
 	assert.Equal(t, atomic.LoadUint32(aliceCount), uint32(10))
 	assert.Equal(t, atomic.LoadUint32(bobCount), uint32(6))
 
-	assert.Equal(t, atomic.LoadUint32(&aliceDisconnected), uint32(0))
+	assert.Equal(t, atomic.LoadUint32(&aliceDisconnected), uint32(1))
 }


### PR DESCRIPTION
Also add a test in `peer_test.go` to check for this condition.

Furthermore, it seem fixing the bug causing two of the tests (one in `node_test.go`, one in `protocol/mod_test.go`) to fail because the two tests were depending on the bug.
So, I've updated the tests.
