### PR TITLE
Fix minor bug in skademlia.prefixLen(b []byte).

### DIFF
--- a/skademlia/binary.go
+++ b/skademlia/binary.go
@@ -65,5 +65,5 @@ func prefixLen(a []byte) int {
 		}
 	}
 
-	return len(a)*8 - 1
+	return len(a)*8
 }

--- a/skademlia/binary_test.go
+++ b/skademlia/binary_test.go
@@ -1,0 +1,16 @@
+package skademlia
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPrefixLen(t *testing.T) {
+	assert.Equal(t, 0, prefixLen(nil))
+
+	assert.Equal(t, 8, prefixLen([]byte{0}))
+
+	assert.Equal(t, 16, prefixLen([]byte{0, 0}))
+
+	assert.Equal(t, 15, prefixLen([]byte{0, 1}))
+}

--- a/skademlia/table.go
+++ b/skademlia/table.go
@@ -174,7 +174,12 @@ func (t *Table) FindClosest(target *ID, k int) []*ID {
 }
 
 func getBucketID(self, target [blake2b.Size256]byte) int {
-	return prefixLen(xor(target[:], self[:]))
+	l := prefixLen(xor(target[:], self[:]))
+	if l == blake2b.Size256 * 8 {
+		return l - 1
+	}
+
+	return l
 }
 
 type Bucket struct {


### PR DESCRIPTION
The bug is only triggered if all the bytes are zero where it'll return wrong result if the bytes are all zero.