### PR TITLE
Allow addresses of nodes in S/Kademlia routing table to be dynamically changed.

### DIFF
--- a/skademlia/table.go
+++ b/skademlia/table.go
@@ -106,11 +106,15 @@ func (t *Table) Update(target *ID) error {
 	}
 
 	b := t.buckets[getBucketID(t.self.checksum, target.checksum)]
-	e := t.Find(b, target)
 
-	if e != nil {
+	if found := t.Find(b, target); found != nil {
 		b.Lock()
-		b.MoveToFront(e)
+
+		// address might differ for same public key (checksum
+		id := found.Value.(*ID)
+		id.address = target.address
+
+		b.MoveToFront(found)
 		b.Unlock()
 
 		return nil


### PR DESCRIPTION
If node is disconnected it's id is not getting deleted from skademlia table.
Then if same node (same public key) is connecting again its getting update in table, but if it has different address it won't get updated.

Added tests to reproduce + fix

https://github.com/perlin-network/wavelet/issues/227