### PR TITLE
Add a global peer blacklist

### DIFF
--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -22,6 +22,7 @@ package skademlia
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"github.com/perlin-network/noise"
 	"github.com/phf/go-queue/queue"
 	"github.com/pkg/errors"

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -213,7 +213,7 @@ func (c *Client) DialContext(ctx context.Context, addr string) (*grpc.ClientConn
 	if err != nil {
 		c.peersLock.Unlock()
 
-		globalPeerBlacklist.Store(addr, now.Add(60 * time.Second))
+		globalPeerBlacklist.Store(addr, now.Add(60*time.Second))
 
 		return nil, errors.Wrap(err, "failed to dial peer")
 	}


### PR DESCRIPTION
Store a list of peer addresses which we are unable to dial, to fail more quickly when dialing peers frequently