### PR TITLE
Use a random delay when blacklisting

### DIFF
--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -212,7 +212,7 @@ func (c *Client) DialContext(ctx context.Context, addr string) (*grpc.ClientConn
 	if err != nil {
 		c.peersLock.Unlock()
 
-		c.peerBlacklist.Store(addr, now.Add((45+rand.Intn(45))*time.Second))
+		c.peerBlacklist.Store(addr, now.Add(time.Duration(45+rand.Intn(45))*time.Second))
 
 		return nil, errors.Wrap(err, "failed to dial peer")
 	}

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -49,9 +50,9 @@ type Client struct {
 	keys  *Keypair
 	table *Table
 
-	peers     map[string]*grpc.ClientConn
+	peers         map[string]*grpc.ClientConn
 	peerBlacklist sync.Map
-	peersLock sync.RWMutex
+	peersLock     sync.RWMutex
 
 	protocol Protocol
 
@@ -211,7 +212,7 @@ func (c *Client) DialContext(ctx context.Context, addr string) (*grpc.ClientConn
 	if err != nil {
 		c.peersLock.Unlock()
 
-		c.peerBlacklist.Store(addr, now.Add(60*time.Second))
+		c.peerBlacklist.Store(addr, now.Add((45+rand.Intn(45))*time.Second))
 
 		return nil, errors.Wrap(err, "failed to dial peer")
 	}


### PR DESCRIPTION
Use a random delay to increase the odds that two peers are not blacklisting each other