### PR TITLE
Improve client/protocol state machine

### DIFF
--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -76,7 +76,7 @@ func NewClient(addr string, keys *Keypair, opts ...Option) *Client {
 		keys:  keys,
 		table: table,
 
-		peers: make(map[string]*grpc.ClientConn),
+		peers:   make(map[string]*grpc.ClientConn),
 		peersID: make(map[string]*ID),
 
 		cleanupChannel: make(chan struct{}),
@@ -290,7 +290,7 @@ func (c *Client) connLoop(conn *grpc.ClientConn) {
 	id = nil
 	failureCount := 0
 
-	state     := connectivity.Idle
+	state := connectivity.Idle
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		changed := conn.WaitForStateChange(ctx, state)

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -350,7 +350,6 @@ func (c *Client) connLoop(conn *grpc.ClientConn) {
 			 * and all references to it should be lost
 			 */
 			if state == connectivity.Shutdown {
-				conn.Close()
 				goto connLoopDone
 			}
 		}
@@ -365,8 +364,9 @@ connLoopDone:
 	 */
 	c.peersLock.Lock()
 	delete(c.peers, conn.Target())
-	conn.Close()
 	c.peersLock.Unlock()
+
+	conn.Close()
 
 	c.logger.Printf("Finish connLoop on %s", conn.Target())
 

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -306,8 +306,6 @@ func (c *Client) connLoop(conn *grpc.ClientConn, id *ID) {
 		state := conn.GetState()
 
 		switch state {
-		case connectivity.TransientFailure:
-			fallthrough
 		case connectivity.Shutdown:
 			c.peersLock.Lock()
 			if _, ok := c.peers[conn.Target()]; ok {

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -334,7 +334,7 @@ func (c *Client) connLoop(conn *grpc.ClientConn) {
 			return
 		}
 
-		changed := conn.WaitForStateChange(context.Background(), conn.GetState())
+		changed := conn.WaitForStateChange(context.Background(), state)
 
 		if !changed {
 			return

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc/peer"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -50,9 +49,9 @@ type Client struct {
 	keys  *Keypair
 	table *Table
 
-	peers         map[string]*grpc.ClientConn
+	peers     map[string]*grpc.ClientConn
 	peerBlacklist sync.Map
-	peersLock     sync.RWMutex
+	peersLock sync.RWMutex
 
 	protocol Protocol
 
@@ -212,7 +211,7 @@ func (c *Client) DialContext(ctx context.Context, addr string) (*grpc.ClientConn
 	if err != nil {
 		c.peersLock.Unlock()
 
-		c.peerBlacklist.Store(addr, now.Add(time.Duration(45+rand.Intn(45))*time.Second))
+		c.peerBlacklist.Store(addr, now.Add(60*time.Second))
 
 		return nil, errors.Wrap(err, "failed to dial peer")
 	}

--- a/skademlia/client_test.go
+++ b/skademlia/client_test.go
@@ -319,6 +319,11 @@ func getClient(t *testing.T, c1, c2 int) (*Client, net.Listener) {
 	c := NewClient(lis.Addr().String(), keys, WithC1(c1), WithC2(c2))
 	c.SetCredentials(noise.NewCredentials(lis.Addr().String(), c.Protocol()))
 
+	go func() {
+		server := c.Listen()
+
+		_ = server.Serve(lis)
+	}()
 	return c, lis
 }
 

--- a/skademlia/protocol.go
+++ b/skademlia/protocol.go
@@ -38,6 +38,49 @@ type Protocol struct {
 	client *Client
 }
 
+func (p Protocol) registerPeerID(info noise.Info, id *ID) error {
+	info.Put(KeyID, id)
+
+	for p.client.table.Update(id) == ErrBucketFull {
+		bucket := p.client.table.buckets[getBucketID(p.client.table.self.checksum, id.checksum)]
+
+		bucket.Lock()
+		last := bucket.Back()
+		lastID := last.Value.(*ID)
+		bucket.Unlock()
+
+		p.client.peersLock.RLock()
+		lastConn, exists := p.client.peers[lastID.address]
+		p.client.peersLock.RUnlock()
+
+		if !exists {
+			p.client.table.Delete(bucket, lastID)
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		if _, err := NewOverlayClient(lastConn).DoPing(ctx, &Ping{}); err != nil {
+			p.client.table.Delete(bucket, lastID)
+			lastConn.Close()
+			cancel()
+			continue
+		}
+		cancel()
+
+		p.client.logger.Printf("Routing table is full; evicting peer %s.\n", id)
+
+		// Ping was successful; disallow the current peer from connecting.
+
+		p.client.peersLock.Lock()
+		delete(p.client.peers, id.address)
+		p.client.peersLock.Unlock()
+
+		return errors.New("skademlia: cannot evict any peers to make room for new peer")
+	}
+
+	return nil
+}
+
 func (p Protocol) handshake(info noise.Info, conn net.Conn) (*ID, error) {
 	buf := p.client.id.Marshal()
 	signature := edwards25519.Sign(p.client.keys.privateKey, buf)
@@ -76,45 +119,6 @@ func (p Protocol) handshake(info noise.Info, conn net.Conn) (*ID, error) {
 
 	ptr := &id
 
-	info.Put(KeyID, ptr)
-
-	for p.client.table.Update(ptr) == ErrBucketFull {
-		bucket := p.client.table.buckets[getBucketID(p.client.table.self.checksum, id.checksum)]
-
-		bucket.Lock()
-		last := bucket.Back()
-		lastID := last.Value.(*ID)
-		bucket.Unlock()
-
-		p.client.peersLock.RLock()
-		lastConn, exists := p.client.peers[lastID.address]
-		p.client.peersLock.RUnlock()
-
-		if !exists {
-			p.client.table.Delete(bucket, lastID)
-			continue
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		if _, err = NewOverlayClient(lastConn).DoPing(ctx, &Ping{}); err != nil {
-			p.client.table.Delete(bucket, lastID)
-			lastConn.Close()
-			cancel()
-			continue
-		}
-		cancel()
-
-		p.client.logger.Printf("Routing table is full; evicting peer %s.\n", id)
-
-		// Ping was successful; disallow the current peer from connecting.
-
-		p.client.peersLock.Lock()
-		delete(p.client.peers, id.address)
-		p.client.peersLock.Unlock()
-
-		return nil, errors.New("skademlia: cannot evict any peers to make room for new peer")
-	}
-
 	return ptr, nil
 }
 
@@ -140,6 +144,9 @@ func (p Protocol) Client(info noise.Info, ctx context.Context, authority string,
 	}
 
 	p.client.logger.Printf("Connected to server %s.\n", id)
+
+	/* We verified that the server is valid, add them to the routing table */
+	p.registerPeerID(info, id)
 
 	return conn, nil
 }
@@ -193,11 +200,17 @@ func (p Protocol) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
 		return nil, err
 	}
 
-	p.client.logger.Printf("Client %s has connected to you.\n", id)
+	p.client.logger.Printf("Client %s has connected to you", id)
 
 	go func() {
 		if _, err = p.client.Dial(id.address, WithTimeout(3*time.Second)); err != nil {
+			p.client.logger.Printf("Client %s was not able to be dialed back, closing connection", id)
 			_ = conn.Close()
+		} else {
+			/* We were able to dial the peer, add them to our table */
+			p.client.logger.Printf("Client %s was successfully dialed back, adding it as a peer", id)
+
+			p.registerPeerID(info, id)
 		}
 	}()
 

--- a/skademlia/protocol_test.go
+++ b/skademlia/protocol_test.go
@@ -78,6 +78,8 @@ func TestProtocol(t *testing.T) {
 	go func() {
 		defer close(accept)
 		serverHandle(t, s.protocol, sinfo, sl)
+		// Wait until node has successfully dialed the peer.
+		time.Sleep(1 * time.Second)
 	}()
 
 	cinfo := noise.Info{}

--- a/skademlia/protocol_test.go
+++ b/skademlia/protocol_test.go
@@ -101,7 +101,7 @@ func TestProtocol(t *testing.T) {
 
 	<-accept
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 
 	// Check ID
 	assert.NotNil(t, cinfo.Get(KeyID))


### PR DESCRIPTION
Only add the peer to the routing table after verifying that it is reachable.   Additionally, this changeset improves dialing such that it does not block with the peers lock held.  Instead, dialing is done asynchronously and when the link first becomes ready it is pinged.