### PR TITLE
Make noise.Info struct to be thread safe

### DIFF
--- a/cipher/protocol.go
+++ b/cipher/protocol.go
@@ -33,7 +33,7 @@ func NewAEAD() ProtocolAEAD {
 	return ProtocolAEAD{}
 }
 
-func (ProtocolAEAD) Client(info noise.Info, ctx context.Context, auth string, conn net.Conn) (net.Conn, error) {
+func (ProtocolAEAD) Client(info *noise.Info, ctx context.Context, auth string, conn net.Conn) (net.Conn, error) {
 	suite, _, err := DeriveAEAD(Aes256GCM(), sha256.New, info.Bytes(handshake.SharedKey), nil)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (ProtocolAEAD) Client(info noise.Info, ctx context.Context, auth string, co
 	return newConnAEAD(suite, conn), nil
 }
 
-func (ProtocolAEAD) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
+func (ProtocolAEAD) Server(info *noise.Info, conn net.Conn) (net.Conn, error) {
 	suite, _, err := DeriveAEAD(Aes256GCM(), sha256.New, info.Bytes(handshake.SharedKey), nil)
 	if err != nil {
 		return nil, err

--- a/cipher/protocol_test.go
+++ b/cipher/protocol_test.go
@@ -17,7 +17,7 @@ func TestProtocol(t *testing.T) {
 	lis := launchServer(t, ecdh, sharedKey, accept)
 	defer lis.Close()
 
-	clientInfo := noise.Info{}
+	clientInfo := noise.NewInfo()
 	clientInfo.PutBytes(handshake.SharedKey, sharedKey)
 	clientConn := clientHandle(t, ecdh, clientInfo, lis.Addr().String())
 
@@ -42,7 +42,7 @@ func TestProtocolKeyMismatch(t *testing.T) {
 	lis := launchServer(t, ecdh, []byte("server_secret_key"), accept)
 	defer lis.Close()
 
-	clientInfo := noise.Info{}
+	clientInfo := noise.NewInfo()
 	clientInfo.PutBytes(handshake.SharedKey, []byte("client_secret_key"))
 	clientConn := clientHandle(t, ecdh, clientInfo, lis.Addr().String())
 
@@ -75,7 +75,7 @@ func serverHandle(t *testing.T, protocol ProtocolAEAD, sharedKey []byte, accept 
 		t.Fatal(err)
 	}
 
-	info := noise.Info{}
+	info := noise.NewInfo()
 	info.PutBytes(handshake.SharedKey, sharedKey)
 	conn, err := protocol.Server(info, rawConn)
 	if err != nil {
@@ -86,7 +86,7 @@ func serverHandle(t *testing.T, protocol ProtocolAEAD, sharedKey []byte, accept 
 	accept <- conn.(*connAEAD)
 }
 
-func clientHandle(t *testing.T, protocol ProtocolAEAD, info noise.Info, lisAddr string) *connAEAD {
+func clientHandle(t *testing.T, protocol ProtocolAEAD, info *noise.Info, lisAddr string) *connAEAD {
 	rawConn, err := net.Dial("tcp", lisAddr)
 	if err != nil {
 		t.Fatal(err)

--- a/credentials.go
+++ b/credentials.go
@@ -35,7 +35,7 @@ func NewCredentials(host string, protocols ...Protocol) *Credentials {
 }
 
 func (c *Credentials) ClientHandshake(ctx context.Context, authority string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	info := make(Info)
+	info := NewInfo()
 	var err error
 
 	for _, protocol := range c.Protocols {
@@ -49,7 +49,7 @@ func (c *Credentials) ClientHandshake(ctx context.Context, authority string, con
 }
 
 func (c *Credentials) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
-	info := make(Info)
+	info := NewInfo()
 	var err error
 
 	for _, protocol := range c.Protocols {

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -13,12 +13,12 @@ type dummmyProtocol struct {
 	serverCall time.Time
 }
 
-func (d *dummmyProtocol) Client(info Info, ctx context.Context, auth string, conn net.Conn) (net.Conn, error) {
+func (d *dummmyProtocol) Client(info *Info, ctx context.Context, auth string, conn net.Conn) (net.Conn, error) {
 	d.clientCall = time.Now()
 	return conn, nil
 }
 
-func (d *dummmyProtocol) Server(info Info, conn net.Conn) (net.Conn, error) {
+func (d *dummmyProtocol) Server(info *Info, conn net.Conn) (net.Conn, error) {
 	d.serverCall = time.Now()
 	return conn, nil
 

--- a/handshake/protocol.go
+++ b/handshake/protocol.go
@@ -39,7 +39,7 @@ func NewECDH() ProtocolECDH {
 	return ProtocolECDH{}
 }
 
-func (ProtocolECDH) Client(info noise.Info, ctx context.Context, auth string, conn net.Conn) (net.Conn, error) {
+func (ProtocolECDH) Client(info *noise.Info, ctx context.Context, auth string, conn net.Conn) (net.Conn, error) {
 	if err := handshakeECDH(info, conn); err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (ProtocolECDH) Client(info noise.Info, ctx context.Context, auth string, co
 	return conn, nil
 }
 
-func (ProtocolECDH) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
+func (ProtocolECDH) Server(info *noise.Info, conn net.Conn) (net.Conn, error) {
 	if err := handshakeECDH(info, conn); err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (ProtocolECDH) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
 	return conn, nil
 }
 
-func handshakeECDH(info noise.Info, conn net.Conn) error {
+func handshakeECDH(info *noise.Info, conn net.Conn) error {
 	ephemeralPublicKey, ephemeralPrivateKey, err := edwards25519.GenerateKey(nil)
 	if err != nil {
 		return errors.New("ecdh: failed to generate ephemeral keypair")

--- a/handshake/protocol_test.go
+++ b/handshake/protocol_test.go
@@ -20,7 +20,7 @@ func TestProtocol(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	accept := make(chan noise.Info)
+	accept := make(chan *noise.Info)
 	go func() {
 		serverRawConn, err := lis.Accept()
 		if err != nil {
@@ -30,7 +30,7 @@ func TestProtocol(t *testing.T) {
 
 		// Initiate server handshake
 
-		info := noise.Info{}
+		info := noise.NewInfo()
 		if _, err := ecdh.Server(info, serverRawConn); err != nil {
 			_ = serverRawConn.Close()
 			close(accept)
@@ -49,7 +49,7 @@ func TestProtocol(t *testing.T) {
 
 	// Initiate client handshake
 
-	clientInfo := noise.Info{}
+	clientInfo := noise.NewInfo()
 	if _, err := ecdh.Client(clientInfo, context.Background(), "", conn); err != nil {
 		t.Fatalf("Error protocol.Client(): %v", err)
 	}
@@ -119,7 +119,7 @@ func TestProtocolBadHandshake(t *testing.T) {
 				}
 
 				ecdh := NewECDH()
-				_, err = ecdh.Server(noise.Info{}, conn)
+				_, err = ecdh.Server(noise.NewInfo(), conn)
 				assert.Error(t, err)
 			}
 
@@ -133,7 +133,7 @@ func TestProtocolBadHandshake(t *testing.T) {
 				}
 
 				ecdh := NewECDH()
-				_, err = ecdh.Client(noise.Info{}, context.Background(), "", conn)
+				_, err = ecdh.Client(noise.NewInfo(), context.Background(), "", conn)
 				assert.Error(t, err)
 			}
 		})
@@ -144,11 +144,11 @@ func TestProtocolConnWriteError(t *testing.T) {
 	ecdh := NewECDH()
 
 	// Test the Write is incomplete
-	_, err := ecdh.Server(noise.Info{}, ErrorConn{isShortWrite: true})
+	_, err := ecdh.Server(noise.NewInfo(), ErrorConn{isShortWrite: true})
 	assert.Error(t, err)
 
 	// Test the Write returns an error
-	_, err = ecdh.Server(noise.Info{}, ErrorConn{isWriteError: true})
+	_, err = ecdh.Server(noise.NewInfo(), ErrorConn{isWriteError: true})
 	assert.Error(t, err)
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -64,7 +64,7 @@ func (i *Info) Put(key string, val interface{}) {
 
 func (i *Info) Get(key string) interface{} {
 	i.mu.RLock()
-	defer i.mu.Unlock()
+	defer i.mu.RUnlock()
 
 	return i.data[key]
 }

--- a/protocol.go
+++ b/protocol.go
@@ -57,42 +57,42 @@ func (*Info) AuthType() string {
 
 func (i *Info) Put(key string, val interface{}) {
 	i.mu.Lock()
-	i.data[key] = val
+	defer i.mu.Unlock()
+
 	i.mu.Unlock()
 }
 
 func (i *Info) Get(key string) interface{} {
 	i.mu.RLock()
-	v := i.data[key]
-	i.mu.RUnlock()
+	defer i.mu.Unlock()
 
-	return v
+	return i.data[key]
 }
 
 func (i *Info) PutString(key, val string) {
 	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	i.data[key] = val
-	i.mu.Unlock()
 }
 
 func (i *Info) String(key string) string {
 	i.mu.RLock()
-	v := i.data[key].(string)
-	i.mu.RUnlock()
+	defer i.mu.RUnlock()
 
-	return v
+	return i.data[key].(string)
 }
 
 func (i *Info) PutBytes(key string, val []byte) {
 	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	i.data[key] = val
-	i.mu.Unlock()
 }
 
 func (i *Info) Bytes(key string) []byte {
 	i.mu.RLock()
-	v := i.data[key].([]byte)
-	i.mu.RUnlock()
+	defer i.mu.RUnlock()
 
-	return v
+	return i.data[key].([]byte)
 }

--- a/protocol.go
+++ b/protocol.go
@@ -59,7 +59,7 @@ func (i *Info) Put(key string, val interface{}) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	i.mu.Unlock()
+	i.data[key] = val
 }
 
 func (i *Info) Get(key string) interface{} {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -10,7 +10,7 @@ func TestInfo(t *testing.T) {
 	p := &peer.Peer{}
 	assert.Nil(t, InfoFromPeer(p))
 
-	p.AuthInfo = Info{}
+	p.AuthInfo = NewInfo()
 
 	info := InfoFromPeer(p)
 	assert.NotNil(t, info)

--- a/skademlia/client_test.go
+++ b/skademlia/client_test.go
@@ -294,8 +294,8 @@ type clientTestContainer struct {
 	client   *Client
 	lis      net.Listener
 	server   *grpc.Server
-	onClient func(noise.Info)
-	onServer func(noise.Info)
+	onClient func(*noise.Info)
+	onServer func(*noise.Info)
 }
 
 // Rename to close
@@ -310,7 +310,7 @@ func (c *clientTestContainer) serve() {
 	}()
 }
 
-func (c *clientTestContainer) Client(info noise.Info, ctx context.Context, authority string, conn net.Conn) (net.Conn, error) {
+func (c *clientTestContainer) Client(info *noise.Info, ctx context.Context, authority string, conn net.Conn) (net.Conn, error) {
 	if c.onClient != nil {
 		c.onClient(info)
 	}
@@ -318,7 +318,7 @@ func (c *clientTestContainer) Client(info noise.Info, ctx context.Context, autho
 	return conn, nil
 }
 
-func (c *clientTestContainer) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
+func (c *clientTestContainer) Server(info *noise.Info, conn net.Conn) (net.Conn, error) {
 	if c.onServer != nil {
 		c.onServer(info)
 	}

--- a/skademlia/protocol.go
+++ b/skademlia/protocol.go
@@ -38,7 +38,7 @@ type Protocol struct {
 	client *Client
 }
 
-func (p Protocol) registerPeerID(info noise.Info, id *ID) error {
+func (p Protocol) registerPeerID(info *noise.Info, id *ID) error {
 	info.Put(KeyID, id)
 
 	for p.client.table.Update(id) == ErrBucketFull {
@@ -81,7 +81,7 @@ func (p Protocol) registerPeerID(info noise.Info, id *ID) error {
 	return nil
 }
 
-func (p Protocol) handshake(info noise.Info, conn net.Conn) (*ID, error) {
+func (p Protocol) handshake(info *noise.Info, conn net.Conn) (*ID, error) {
 	buf := p.client.id.Marshal()
 	signature := edwards25519.Sign(p.client.keys.privateKey, buf)
 
@@ -122,7 +122,7 @@ func (p Protocol) handshake(info noise.Info, conn net.Conn) (*ID, error) {
 	return ptr, nil
 }
 
-func (p Protocol) Client(info noise.Info, ctx context.Context, authority string, conn net.Conn) (net.Conn, error) {
+func (p Protocol) Client(info *noise.Info, ctx context.Context, authority string, conn net.Conn) (net.Conn, error) {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 
@@ -191,7 +191,7 @@ func addressMatches(bind string, subject string) bool {
 	return false
 }
 
-func (p Protocol) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
+func (p Protocol) Server(info *noise.Info, conn net.Conn) (net.Conn, error) {
 	id, err := p.handshake(info, conn)
 	if err != nil {
 		if cerr := conn.Close(); cerr != nil {

--- a/skademlia/protocol_test.go
+++ b/skademlia/protocol_test.go
@@ -77,13 +77,13 @@ func TestProtocol(t *testing.T) {
 	s.serve()
 	defer s.cleanup()
 
-	var sinfo noise.Info
-	s.onServer = func(info noise.Info) {
+	var sinfo *noise.Info
+	s.onServer = func(info *noise.Info) {
 		sinfo = info
 	}
 
-	var cinfo noise.Info
-	c.onClient = func(info noise.Info) {
+	var cinfo *noise.Info
+	c.onClient = func(info *noise.Info) {
 		cinfo = info
 	}
 
@@ -224,7 +224,7 @@ func TestProtocolBadHandshake(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				_, err = c.client.protocol.Server(noise.Info{}, conn)
+				_, err = c.client.protocol.Server(noise.NewInfo(), conn)
 				assert.Error(t, err)
 			}
 
@@ -239,7 +239,7 @@ func TestProtocolBadHandshake(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				_, err = c.client.protocol.Client(noise.Info{}, context.Background(), "", conn)
+				_, err = c.client.protocol.Client(noise.NewInfo(), context.Background(), "", conn)
 				assert.Error(t, err)
 			}
 		})
@@ -272,7 +272,7 @@ func TestProtocolHandshakeClientBadAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.client.protocol.Client(noise.Info{}, context.Background(), "", conn)
+	_, err = c.client.protocol.Client(noise.NewInfo(), context.Background(), "", conn)
 	assert.Error(t, err)
 }
 
@@ -301,7 +301,7 @@ func TestProtocolHandshakeSamePeerID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = c.client.protocol.handshake(noise.Info{}, conn)
+	_, err = c.client.protocol.handshake(noise.NewInfo(), conn)
 	assert.Error(t, err)
 }
 
@@ -309,11 +309,11 @@ func TestProtocolConnWriteError(t *testing.T) {
 	c := newClientTestContainer(t, 1, 1)
 
 	// Test the Write is incomplete
-	_, err := c.client.protocol.handshake(noise.Info{}, ErrorConn{isShortWrite: true})
+	_, err := c.client.protocol.handshake(noise.NewInfo(), ErrorConn{isShortWrite: true})
 	assert.Error(t, err)
 
 	// Test the Write returns an error
-	_, err = c.client.protocol.handshake(noise.Info{}, ErrorConn{isWriteError: true})
+	_, err = c.client.protocol.handshake(noise.NewInfo(), ErrorConn{isWriteError: true})
 	assert.Error(t, err)
 }
 
@@ -323,7 +323,7 @@ func serverHandle(t *testing.T, protocol Protocol, info noise.Info, lis net.List
 		return
 	}
 
-	if _, err := protocol.Server(info, serverRawConn); err != nil {
+	if _, err := protocol.Server(&info, serverRawConn); err != nil {
 		_ = serverRawConn.Close()
 		t.Fatalf("Error server: %v", err)
 	}
@@ -334,7 +334,7 @@ func clientHandle(t *testing.T, protocol Protocol, info noise.Info, lisAddr stri
 	if err != nil {
 		t.Fatalf("Error client: %v", err)
 	}
-	_, err = protocol.Client(info, context.Background(), "", conn)
+	_, err = protocol.Client(&info, context.Background(), "", conn)
 	if err != nil {
 		t.Fatalf("Error client: %v", err)
 	}


### PR DESCRIPTION
Currently, there's a race condition since the Info is modified concurrently.

This PR fixes the race condition by making Info to be thread safe by using mutex.
Because of the mutex, we have to make its methods to have pointer receivers.