### PR TITLE
Fix a data race in noise.Info

### DIFF
--- a/skademlia/protocol.go
+++ b/skademlia/protocol.go
@@ -38,9 +38,7 @@ type Protocol struct {
 	client *Client
 }
 
-func (p Protocol) registerPeerID(info noise.Info, id *ID) error {
-	info.Put(KeyID, id)
-
+func (p Protocol) registerPeerID(id *ID) error {
 	for p.client.table.Update(id) == ErrBucketFull {
 		bucket := p.client.table.buckets[getBucketID(p.client.table.self.checksum, id.checksum)]
 
@@ -145,6 +143,8 @@ func (p Protocol) Client(info noise.Info, ctx context.Context, authority string,
 
 	p.client.logger.Printf("Connected to server %s.\n", id)
 
+	info.Put(KeyID, id)
+
 	/* We verified that the server is valid, add them to the routing table */
 	p.registerPeerID(info, id)
 
@@ -201,6 +201,8 @@ func (p Protocol) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
 	}
 
 	p.client.logger.Printf("Client %s has connected to you", id)
+
+	info.Put(KeyID, id)
 
 	go func() {
 		if _, err = p.client.Dial(id.address, WithTimeout(3*time.Second)); err != nil {

--- a/skademlia/protocol.go
+++ b/skademlia/protocol.go
@@ -146,7 +146,7 @@ func (p Protocol) Client(info noise.Info, ctx context.Context, authority string,
 	info.Put(KeyID, id)
 
 	/* We verified that the server is valid, add them to the routing table */
-	p.registerPeerID(info, id)
+	_ = p.registerPeerID(id)
 
 	return conn, nil
 }
@@ -212,7 +212,7 @@ func (p Protocol) Server(info noise.Info, conn net.Conn) (net.Conn, error) {
 			/* We were able to dial the peer, add them to our table */
 			p.client.logger.Printf("Client %s was successfully dialed back, adding it as a peer", id)
 
-			p.registerPeerID(info, id)
+			_ = p.registerPeerID(id)
 		}
 	}()
 


### PR DESCRIPTION
Currently, there's a data race on noise.Info because it's modified on another Goroutine after dialling the peer.

This PR fixes the data race by move the modification to the original Goroutine.
This means the we set the ID first before starting another Goroutine to dial the peer and if the dial successful, add it to the table.

This PR also reworks the eviction unit test and minor cleans code.

