### PR TITLE
Allow noise to work if CPU does not support AES-NI

### DIFF
--- a/cipher/cipher.go
+++ b/cipher/cipher.go
@@ -22,10 +22,10 @@ package cipher
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"hash"
+
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/hkdf"
-	"golang.org/x/sys/cpu"
-	"hash"
 )
 
 type suiteFn func([]byte) (cipher.AEAD, error)
@@ -51,9 +51,9 @@ func DeriveAEAD(suiteFn suiteFn, hashFn hashFn, ephemeralSharedKey []byte, conte
 
 // AEAD via. AES-256 GCM (Galois Counter Mode).
 func Aes256GCM() func(sharedKey []byte) (cipher.AEAD, error) {
-	if !cpu.Initialized || (cpu.Initialized && !cpu.ARM64.HasAES && !cpu.X86.HasAES && !cpu.S390X.HasAESGCM) {
-		panic("UNSUPPORTED: CPU does not support AES-NI instructions.")
-	}
+	// if !cpu.Initialized || (cpu.Initialized && !cpu.ARM64.HasAES && !cpu.X86.HasAES && !cpu.S390X.HasAESGCM) {
+	// 	panic("UNSUPPORTED: CPU does not support AES-NI instructions.")
+	// }
 
 	return func(sharedKey []byte) (cipher.AEAD, error) {
 		block, _ := aes.NewCipher(sharedKey)

--- a/cipher/cipher.go
+++ b/cipher/cipher.go
@@ -51,6 +51,7 @@ func DeriveAEAD(suiteFn suiteFn, hashFn hashFn, ephemeralSharedKey []byte, conte
 
 // AEAD via. AES-256 GCM (Galois Counter Mode).
 func Aes256GCM() func(sharedKey []byte) (cipher.AEAD, error) {
+	// TODO: document this somewhere, and/or use an alternative implementation of AES
 	// if !cpu.Initialized || (cpu.Initialized && !cpu.ARM64.HasAES && !cpu.X86.HasAES && !cpu.S390X.HasAESGCM) {
 	// 	panic("UNSUPPORTED: CPU does not support AES-NI instructions.")
 	// }


### PR DESCRIPTION
This PR removes the check which panics if the CPU does not support AES-NI instructions. Without AES-NI support, the AES implementation [provided by Go](https://golang.org/pkg/crypto/aes) is [not constant-time](https://github.com/golang/go/issues/16821/).

This change is done to allow noise to work on CPU which does not support AES-NI instructions, like Raspberry pi.