### PR TITLE
Implement a type to wrap conn and id, returned by ClosestPeers

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -120,10 +120,10 @@ func main() {
 			panic(err)
 		}
 
-		conns := client.ClosestPeers()
+		closestPeers := client.ClosestPeers()
 
-		for _, conn := range conns {
-			chat := NewChatClient(conn)
+		for _, closestPeer := range closestPeers {
+			chat := NewChatClient(closestPeer.Conn())
 
 			stream, err := chat.Stream(context.Background())
 			if err != nil {

--- a/skademlia/client.go
+++ b/skademlia/client.go
@@ -138,18 +138,21 @@ func (c *Client) AllPeers() []*grpc.ClientConn {
 	return conns
 }
 
-func (c *Client) ClosestPeers(opts ...DialOption) []*grpc.ClientConn {
+func (c *Client) ClosestPeers(opts ...DialOption) []ClosestPeer {
 	ids := c.table.FindClosest(c.table.self, c.table.getBucketSize())
 
-	var conns []*grpc.ClientConn
+	var peers []ClosestPeer
 
 	for i := range ids {
 		if conn, err := c.Dial(ids[i].address, opts...); err == nil {
-			conns = append(conns, conn)
+			peers = append(peers, ClosestPeer{
+				conn: conn,
+				id:   ids[i],
+			})
 		}
 	}
 
-	return conns
+	return peers
 }
 
 func (c *Client) ClosestPeerIDs() []*ID {
@@ -611,4 +614,17 @@ func (s InterceptedServerStream) RecvMsg(m interface{}) error {
 	}
 
 	return nil
+}
+
+type ClosestPeer struct {
+	conn *grpc.ClientConn
+	id   *ID
+}
+
+func (c ClosestPeer) Conn() *grpc.ClientConn {
+	return c.conn
+}
+
+func (c ClosestPeer) ID() *ID {
+	return c.id
 }


### PR DESCRIPTION
Currently, `ClosestPeers()` returns a list of connections, without their IDs. What if we also want connection ID ?
The only way get both ID and connection is to do it yourself, by manually calling `ClosestPeerIDs` and call `Dial` on each ID.

This PR introduces a type that wraps connection and ID, to be returned by `ClosestPeers()`.