### PR TITLE
Align atomic values

### DIFF
--- a/callbacks/sequential.go
+++ b/callbacks/sequential.go
@@ -9,10 +9,10 @@ import (
 const autoTrimThreshold = 10
 
 type SequentialCallbackManager struct {
-	callbacksMutex sync.Mutex // this mutex only protects the `callbacks` pointer itself.
-
-	callbacks           *[]callbackState
 	pendingRemovalCount uint64
+
+	callbacksMutex sync.Mutex // this mutex only protects the `callbacks` pointer itself.
+	callbacks      *[]callbackState
 
 	reverse bool
 }


### PR DESCRIPTION
On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.
Fixes #264 