### PR TITLE
client, conn: remove idle timeout goroutine and use net.Conn read/write deadlines instead

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -274,8 +274,7 @@ func TestIdleTimeoutServerSide(t *testing.T) {
 	ab.WaitUntilClosed()
 
 	var abError *net.OpError
-	assert.True(t, errors.As(ab.Error(), &abError))
-	assert.True(t, abError.Timeout())
+	assert.True(t, errors.As(ab.Error(), &abError) && abError.Timeout() || ab.Error() == io.EOF)
 
 	assert.EqualValues(t, ba.Error(), io.EOF)
 
@@ -311,8 +310,7 @@ func TestIdleTimeoutClientSide(t *testing.T) {
 	ab.WaitUntilClosed()
 
 	var baError *net.OpError
-	assert.True(t, errors.As(ba.Error(), &baError))
-	assert.True(t, baError.Timeout())
+	assert.True(t, errors.As(ba.Error(), &baError) && baError.Timeout() || ba.Error() == io.EOF)
 
 	assert.EqualValues(t, ab.Error(), io.EOF)
 

--- a/node_test.go
+++ b/node_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 	"io"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -272,7 +273,10 @@ func TestIdleTimeoutServerSide(t *testing.T) {
 	ba.WaitUntilClosed()
 	ab.WaitUntilClosed()
 
-	assert.EqualValues(t, ab.Error(), context.DeadlineExceeded)
+	var abError *net.OpError
+	assert.True(t, errors.As(ab.Error(), &abError))
+	assert.True(t, abError.Timeout())
+
 	assert.EqualValues(t, ba.Error(), io.EOF)
 
 	assert.Len(t, a.Inbound(), 0)
@@ -306,7 +310,10 @@ func TestIdleTimeoutClientSide(t *testing.T) {
 	ba.WaitUntilClosed()
 	ab.WaitUntilClosed()
 
-	assert.EqualValues(t, ba.Error(), context.DeadlineExceeded)
+	var baError *net.OpError
+	assert.True(t, errors.As(ba.Error(), &baError))
+	assert.True(t, baError.Timeout())
+
 	assert.EqualValues(t, ab.Error(), io.EOF)
 
 	assert.Len(t, a.Inbound(), 0)


### PR DESCRIPTION
This removes the need for there being one extraneous goroutine per connection and removes the need for keeping track of an idle timeout timer per *noise.Client.