### PR TITLE
node, node/opts, error, client, conn, readme: implement option to set max recv message size limit with default set to 2mb, and use uints for configurable values that should be non-negative

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - Peers attempt to be dialed at most three times.
 - A total of 128 outbound connections are allowed at any time.
 - A total of 128 inbound connections are allowed at any time.
+- Peers may send in a single message, at most, 2MB worth of data.
 - Connections timeout after 10 seconds if no reads/writes occur.
 
 ## Dependencies

--- a/client.go
+++ b/client.go
@@ -526,7 +526,7 @@ func (c *Client) writeLoop(conn net.Conn) {
 func (c *Client) readLoop(conn net.Conn) {
 	defer close(c.readerDone)
 
-	if err := c.reader.loop(conn, c.node.idleTimeout); err != nil {
+	if err := c.reader.loop(conn, c.node.idleTimeout, c.node.maxRecvMessageSize); err != nil {
 		if !isEOF(err) {
 			c.Logger().Warn("Got an error while reading incoming messages.", zap.Error(err))
 		}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,7 @@
+package noise
+
+import "errors"
+
+var (
+	ErrMessageTooLarge = errors.New("msg from peer is too large")
+)

--- a/map.go
+++ b/map.go
@@ -15,12 +15,12 @@ type clientMapEntry struct {
 type clientMap struct {
 	sync.Mutex
 
-	cap     int
+	cap     uint
 	order   *list.List
 	entries map[string]clientMapEntry
 }
 
-func newClientMap(cap int) *clientMap {
+func newClientMap(cap uint) *clientMap {
 	return &clientMap{
 		cap:     cap,
 		order:   list.New(),
@@ -34,7 +34,7 @@ func (c *clientMap) get(n *Node, addr string) (*Client, bool) {
 
 	entry, exists := c.entries[addr]
 	if !exists {
-		if len(c.entries) == n.maxInboundConnections {
+		if uint(len(c.entries)) == n.maxInboundConnections {
 			el := c.order.Back()
 			evicted := c.order.Remove(el).(string)
 

--- a/node_options.go
+++ b/node_options.go
@@ -12,9 +12,9 @@ type NodeOption func(n *Node)
 
 // WithNodeMaxDialAttempts sets the max number of attempts a connection is dialed before it is determined to have
 // failed. By default, the max number of attempts a connection is dialed is 3.
-func WithNodeMaxDialAttempts(maxDialAttempts int) NodeOption {
+func WithNodeMaxDialAttempts(maxDialAttempts uint) NodeOption {
 	return func(n *Node) {
-		if maxDialAttempts <= 0 {
+		if maxDialAttempts == 0 {
 			maxDialAttempts = 1
 		}
 
@@ -25,9 +25,9 @@ func WithNodeMaxDialAttempts(maxDialAttempts int) NodeOption {
 // WithNodeMaxInboundConnections sets the max number of inbound connections the connection pool a node maintains allows
 // at any given moment in time. By default, the max number of inbound connections is 128. Exceeding the max number
 // causes the connection pool to release the oldest inbound connection in the pool.
-func WithNodeMaxInboundConnections(maxInboundConnections int) NodeOption {
+func WithNodeMaxInboundConnections(maxInboundConnections uint) NodeOption {
 	return func(n *Node) {
-		if maxInboundConnections <= 0 {
+		if maxInboundConnections == 0 {
 			maxInboundConnections = 128
 		}
 
@@ -38,13 +38,22 @@ func WithNodeMaxInboundConnections(maxInboundConnections int) NodeOption {
 // WithNodeMaxOutboundConnections sets the max number of outbound connections the connection pool a node maintains
 // allows at any given moment in time. By default, the maximum number of outbound connections is 128. Exceeding the
 // max number causes the connection pool to release the oldest outbound connection in the pool.
-func WithNodeMaxOutboundConnections(maxOutboundConnections int) NodeOption {
+func WithNodeMaxOutboundConnections(maxOutboundConnections uint) NodeOption {
 	return func(n *Node) {
-		if maxOutboundConnections <= 0 {
+		if maxOutboundConnections == 0 {
 			maxOutboundConnections = 128
 		}
 
 		n.maxOutboundConnections = maxOutboundConnections
+	}
+}
+
+// WithNodeMaxRecvSize sets the max number of bytes a node is willing to receive from a peer. If the limit is ever
+// exceeded, the peer is disconnected with an error. Setting this option to zero will disable the limit. By default,
+// the max number of bytes a node is willing to receive from a peer is set to 2MB.
+func WithNodeMaxRecvMessageSize(maxRecvMessageSize uint32) NodeOption {
+	return func(n *Node) {
+		n.maxRecvMessageSize = maxRecvMessageSize
 	}
 }
 

--- a/node_options_test.go
+++ b/node_options_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestNodeOptions(t *testing.T) {
-	a := func(a int) bool {
-		if a <= 0 {
+	a := func(a uint) bool {
+		if a == 0 {
 			a = 1
 		}
 
@@ -29,8 +29,8 @@ func TestNodeOptions(t *testing.T) {
 
 	assert.NoError(t, quick.Check(a, &quick.Config{MaxCount: 10}))
 
-	b := func(a int) bool {
-		if a <= 0 {
+	b := func(a uint) bool {
+		if a == 0 {
 			a = 128
 		} else if a > 1000 {
 			a = 1000
@@ -50,8 +50,8 @@ func TestNodeOptions(t *testing.T) {
 
 	assert.NoError(t, quick.Check(b, &quick.Config{MaxCount: 10}))
 
-	c := func(a int) bool {
-		if a <= 0 {
+	c := func(a uint) bool {
+		if a == 0 {
 			a = 128
 		} else if a > 1000 {
 			a = 1000


### PR DESCRIPTION
Implements max message size limits.