### PR TITLE
Extends cryptographic keys API, reduce frequency of OnMessageSent being called, improve cache locality of Kademlia routing table.

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/oasislabs/ed25519"
 	"go.uber.org/zap"
 	"io"
 	"net"
@@ -428,7 +427,7 @@ func (c *Client) handshake() {
 
 	if len(data) != SizePublicKey+SizeSignature {
 		c.reportError(fmt.Errorf("received invalid number of bytes opening a session: expected %d byte(s), but got %d byte(s)",
-			ed25519.PublicKeySize+ed25519.SignatureSize,
+			SizePublicKey+SizeSignature,
 			len(data),
 		))
 

--- a/kademlia/protocol.go
+++ b/kademlia/protocol.go
@@ -103,8 +103,7 @@ func (p *Protocol) Ack(id noise.ID) {
 			return
 		}
 
-		bucket := p.table.Bucket(id.ID)
-		last := bucket[len(bucket)-1]
+		last := p.table.Last(id.ID)
 
 		ctx, cancel := context.WithTimeout(context.Background(), p.pingTimeout)
 		pong, err := p.node.RequestMessage(ctx, last.Address, Ping{})

--- a/mod.go
+++ b/mod.go
@@ -39,7 +39,7 @@ type Protocol struct {
 	// OnPingFailed is called whenever any attempt by a node to dial a peer at addr fails.
 	OnPingFailed func(addr string, err error)
 
-	// OnMessageSent is called whenever a message or request is successfully sent to a peer.
+	// OnMessageSent is called whenever bytes of a message or request or response have been flushed/sent to a peer.
 	OnMessageSent func(client *Client)
 
 	// OnMessageRecv is called whenever a message or response is received from a peer.

--- a/node.go
+++ b/node.go
@@ -323,14 +323,6 @@ func (n *Node) Send(ctx context.Context, addr string, data []byte) error {
 		return err
 	}
 
-	for _, protocol := range c.node.protocols {
-		if protocol.OnMessageSent == nil {
-			continue
-		}
-
-		protocol.OnMessageSent(c)
-	}
-
 	return nil
 }
 
@@ -357,14 +349,6 @@ func (n *Node) Request(ctx context.Context, addr string, data []byte) ([]byte, e
 	msg, err := c.request(ctx, data)
 	if err != nil {
 		return nil, err
-	}
-
-	for _, protocol := range c.node.protocols {
-		if protocol.OnMessageSent == nil {
-			continue
-		}
-
-		protocol.OnMessageSent(c)
 	}
 
 	return msg.data, nil
@@ -485,7 +469,7 @@ func (n *Node) Handle(handlers ...Handler) {
 }
 
 // Sign uses the nodes private key to sign data and return its cryptographic signature as a slice of bytes.
-func (n *Node) Sign(data []byte) []byte {
+func (n *Node) Sign(data []byte) Signature {
 	return n.privateKey.Sign(data)
 }
 


### PR DESCRIPTION
Few security considerations were implemented alongside helper methods for dealing with cryptographic keys. After benchmarking with software written on top of Noise, a switch from using a pre-allocated slice to a linked list was done for representing Kademlia routing tables.

```
client, node: have OnMessageSent called less frequently
kademlia/protocol, kademlia/table: switch from using a slice to a linked list for representing the routing table to make id updates more efficient, and add Last() to get the last entry of a bucket near a target public key
client, node, keys: add LoadKeysFromHex to load a private key from hex, add Signature type to represent cryptographic signatures, and add UnmarshalSignature which uses unsafe hackery to convert a byte slice into a signature
client: add missing check for length of overlay handshake
```