### PR TITLE
Reduce AEAD allocations, and switched to using sync.Cond for reducing lock contention in clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 ## Dependencies
 
 - Logging is handled by [uber-go/zap](https://github.com/uber-go/zap).
-- Byte buffer pooling is handled by [valyala/bytebufferpool](https://github.com/valyala/bytebufferpool).
 - Unit tests are handled by [stretchr/testify](https://github.com/stretchr/testify).
 - Ed25519 signatures are handled by [oasislabs/ed25519](https://github.com/oasislabs/ed25519).
 - Elliptic-curve Diffie Hellman Key Exchange (ECDH) over Curve25519 is handled by [agl/ed25519](https://github.com/agl/ed25519).

--- a/aead.go
+++ b/aead.go
@@ -7,13 +7,15 @@ import (
 )
 
 func encryptAEAD(suite cipher.AEAD, buf []byte) ([]byte, error) {
-	nonce := make([]byte, suite.NonceSize())
+	a, b := suite.NonceSize(), len(buf)
 
-	if _, err := rand.Read(nonce[:]); err != nil {
+	buf = append(make([]byte, a), append(buf, make([]byte, suite.Overhead())...)...)
+
+	if _, err := rand.Read(buf[:a]); err != nil {
 		return nil, err
 	}
 
-	return append(nonce, suite.Seal(buf[:0], nonce[:suite.NonceSize()], buf, nil)...), nil
+	return append(buf[:a], suite.Seal(buf[a:a], buf[:a], buf[a:a+b], nil)...), nil
 }
 
 func decryptAEAD(suite cipher.AEAD, buf []byte) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/oasislabs/ed25519 v0.0.0-20191122104632-9d9ffc15f526
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/valyala/bytebufferpool v1.0.0
 	go.uber.org/atomic v1.5.1
 	go.uber.org/goleak v1.0.0
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
-github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.5.1 h1:rsqfU5vBkVknbhUGbAUwQKR2H4ItV8tjJ+6kJX4cxHM=


### PR DESCRIPTION
Shaved away an allocation in `encryptAEAD`, and switched to using `sync.Cond` for reducing lock contention in `client.go` when sending large amounts of messages with high flush latency.