### PR TITLE
fix depreciated requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.5.7
-	github.com/oasislabs/ed25519 v0.0.0-20200302143042-29f6767a7c3e
+	github.com/oasisprotocol/ed25519 v0.0.0-20200528083105-55566edd6df0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/atomic v1.5.1


### PR DESCRIPTION
`go version go1.15.2 darwin/amd64`

[Issue](https://github.com/perlin-network/noise/issues/287)

Problem
<img width="693" alt="Screenshot 2020-09-14 at 7 04 26 PM" src="https://user-images.githubusercontent.com/40539705/93092491-1d5b5c80-f6bd-11ea-8233-7820819d6533.png">

Fix 
Update go.mod, change the requirement from `github.com/oasislabs/ed25519 v0.0.0-20200302143042-29f6767a7c3e` to `github.com/oasisprotocol/ed25519 v0.0.0-20200528083105-55566edd6df0`
