### PR TITLE
use crypto/rand package instead of math/rand

### DIFF
--- a/aead.go
+++ b/aead.go
@@ -2,8 +2,8 @@ package noise
 
 import (
 	"crypto/cipher"
+	"crypto/rand"
 	"io"
-	"math/rand"
 )
 
 func extendFront(buf []byte, n int) []byte {


### PR DESCRIPTION
### Reference issue: #289

#### There is a small mistake that has potentially big security-related consequences. I replaced the "math/rand" package in **aead.go** to "crypto/rand".

This PR fixes issue #289 as "crypto/rand" is a more secure solution and the package that is officially advised by the Go core team. It produces a stronger random number or psuedo-random number and is a more secure solution than "math/rand". This PR fixes the issue and should be easy to merge as only 2 lines are changed and they are both inside of the imports array (the replacement plus the sorting of imports added a line to the diff).

#### I looked to see if you had any contributing guidelines as I would love to help contribute further to this project. Fantastic work with everything so far. I love it. 👍 