### PR TITLE
Fix Repeating Nonces

### DIFF
--- a/aead.go
+++ b/aead.go
@@ -100,11 +100,16 @@ func (e *aeadEncryption) decrypt(buf []byte) ([]byte, error) {
 	nonce := buf[:e.suite.NonceSize()]
 	text := buf[e.suite.NonceSize():]
 
+	cleartext, err := e.suite.Open(text[:0], nonce, text, nil)
+	if err != nil {
+		return cleartext, err
+	}
+
 	// Handle edge case where both parties generate the same 4 starting bytes
 	// The best solution to this would be the parties generate a nonce prefix together
 	// This also has some chance of still generating the same data
 	if bytes.Equal(e.fixed[:], nonce[:4]) {
 		e.regenerateNonce()
 	}
-	return e.suite.Open(text[:0], nonce, text, nil)
+	return cleartext, err
 }

--- a/client.go
+++ b/client.go
@@ -3,8 +3,6 @@ package noise
 import (
 	"bufio"
 	"context"
-	"crypto/aes"
-	"crypto/cipher"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -437,20 +435,10 @@ func (c *Client) handshake() {
 	// Use the derived shared key from Diffie-Hellman to encrypt/decrypt all future communications
 	// with AES-256 Galois Counter Mode (GCM).
 
-	core, err := aes.NewCipher(shared[:])
+	c.suite, err = newAEAD(shared[:])
 	if err != nil {
 		c.reportError(fmt.Errorf("could not instantiate aes: %w", err))
-		return
 	}
-
-	suite, err := cipher.NewGCM(core)
-	if err != nil {
-		c.reportError(fmt.Errorf("could not instantiate aes-gcm: %w", err))
-		return
-	}
-
-	c.suite = aeadEncryption{suite}
-
 	// Send to our peer our overlay ID.
 
 	buf := c.node.id.Marshal()


### PR DESCRIPTION
An extension to #291, and (hopefully) full solution to #289

This change the random data generation to a cryptographically secure source and implements a repetition resistant nonce generation algorithm, which handles some edge cases where nonce reuse might occur. 

This needs a bit of a look over to make sure its both backwards compatible and not missing anything.
