### PR TITLE
Simplify addr.go logic when resolving IP

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -13,26 +13,21 @@ func ResolveAddress(address string) (string, error) {
 		return "", err
 	}
 
-	addr.IP = resolveIP(addr.IP)
+	if !isAllowedIP(addr.IP) {
+		addr.IP = nil
+	}
 
 	return addr.String(), nil
 }
 
-func resolveIP(ip net.IP) net.IP {
-	if ip.IsLoopback() || ip.IsUnspecified() {
-		return nil
-	}
-
-	return ip
+func isAllowedIP(ip net.IP) bool {
+	return !(ip.IsLoopback() || ip.IsUnspecified() || ip.String() == "<nil>")
 }
 
 func normalizeIP(ip net.IP) string {
-	ip = resolveIP(ip)
-
-	str := ip.String()
-	if str == "<nil>" {
-		return ""
+	if isAllowedIP(ip) {
+		return ip.String()
 	}
 
-	return str
+	return ""
 }


### PR DESCRIPTION
I was reading the project source code and found that `addr.go` functions can be
more readable.

The function resolveIP what it was really doing is rejecting the IP in certain
cases so it's ought to check the IP and return boolean in case it's not a valid
IP. so I rewrote it to do so and then changed the usage. that simplified the
other two functions `ResolveAddress` and `normalizeIP`
